### PR TITLE
Add .ko files as %ghost and only require kernel if we need to

### DIFF
--- a/kmod-nvidia.spec
+++ b/kmod-nvidia.spec
@@ -264,31 +264,15 @@ install -m 755 ld.gold %{buildroot}/%{postld}
 %files
 %defattr(644,root,root,755)
 
-# nvidia.o
-%{kmod_o_dir}/nvidia.mod.o
-%{kmod_o_dir}/nvidia.sig
-%{kmod_o_dir}/nvidia/nv-interface.o
-%{kmod_o_dir}/nvidia/nv-kernel.o
-
-# nvidia-uvm.o
-%{kmod_o_dir}/nvidia-uvm.mod.o
-%{kmod_o_dir}/nvidia-uvm.sig
-%{kmod_o_dir}/nvidia-uvm/nvidia-uvm.o
-
-# nvidia-modeset.o
-%{kmod_o_dir}/nvidia-modeset.mod.o
-%{kmod_o_dir}/nvidia-modeset.sig
-%{kmod_o_dir}/nvidia-modeset/nv-modeset-interface.o
-%{kmod_o_dir}/nvidia-modeset/nv-modeset-kernel.o
-
-# nvidia-drm.o
-%{kmod_o_dir}/nvidia-drm.mod.o
-%{kmod_o_dir}/nvidia-drm.sig
-%{kmod_o_dir}/nvidia-drm/nvidia-drm.o
-
+%{kmod_o_dir}
+%{kmod_share_dir}
 %{postld}
 
-%{kmod_share_dir}/module-common.lds
+%ghost %{kmod_module_path}
+%ghost %{kmod_module_path}/nvidia.ko
+%ghost %{kmod_module_path}/nvidia-uvm.ko
+%ghost %{kmod_module_path}/nvidia-drm.ko
+%ghost %{kmod_module_path}/nvidia-modeset.ko
 
 %clean
 rm -rf $RPM_BUILD_ROOT

--- a/kmod-nvidia.spec
+++ b/kmod-nvidia.spec
@@ -84,7 +84,7 @@ Supplements: (nvidia-driver = %{epoch}:%{kmod_driver_version} and kernel = %{kmo
 
 # This works though and will automatically remove the kmod package when removing
 # the kernel package.
-Requires: kernel = %{kmod_kernel_version}
+Requires: (kernel = %{kmod_kernel_version} if kernel)
 Conflicts: kmod-nvidia-latest-dkms
 
 %endif # fedora/rhel8

--- a/kmod-nvidia.spec
+++ b/kmod-nvidia.spec
@@ -51,7 +51,7 @@ Source2:	public_key.der
 
 Name:		kmod-%{kmod_vendor}-%{kmod_driver_version}-%{kmod_kernel}-%{kmod_kernel_release}
 Version:	%{kmod_driver_version}
-Release:	3%{kmod_dist}
+Release:	4%{kmod_dist}
 Summary:	NVIDIA graphics driver
 Group:		System/Kernel
 License:	Nvidia
@@ -278,6 +278,10 @@ install -m 755 ld.gold %{buildroot}/%{postld}
 rm -rf $RPM_BUILD_ROOT
 
 %changelog
+* Thu May 07 2020 Timm Bäder <tbaeder@redhat.com>
+ - List generated files as %%ghost files
+ - Only require the kernel if any kernel is installed
+
 * Thu Apr 30 2020 Kevin Mittman <kmittman@nvidia.com>
  - Unique ld.gold filename
 


### PR DESCRIPTION
Hi,

see the commits. Only requiring a kernel if a kernel is already installed is a cheesy way of not pulling in a kernel package in a container environment. Normal systems will always have at least one kernel package installed of course.

I know the `%ghost` files were removed in 3d3007258e0f73bee9ea2674c5d565afacac78de, but I think that was for the RHEL 7 spec file and it seems to work fine in my tests on RHEL 8.

