### PR TITLE
Additional modularity profiles

### DIFF
--- a/genmodules.py
+++ b/genmodules.py
@@ -347,6 +347,20 @@ if __name__ == '__main__':
         if branch.is_dkms():
             out.tab().tab().tab().tab().line('- kmod-nvidia-latest-dkms')
 
+        out.tab().tab().line('fm:')
+        out.tab().tab().tab().line('description: FabricManager installation')
+        out.tab().tab().tab().line('rpms:')
+        for pkg in sorted(existing_branch_pkgs):
+            out.tab().tab().tab().tab().line('- ' + pkg)
+        if branch.is_dkms():
+            out.tab().tab().tab().tab().line('- kmod-nvidia-latest-dkms')
+        if "latest" in branch.name:
+            out.tab().tab().tab().tab().line('- ' + 'nvidia-fabricmanager-' + latest.major)
+            out.tab().tab().tab().tab().line('- ' + 'libnvidia-nscq-' + latest.major)
+        else:
+            out.tab().tab().tab().tab().line('- ' + 'nvidia-fabricmanager-' + branch.major)
+            out.tab().tab().tab().tab().line('- ' + 'libnvidia-nscq-' + branch.major)
+
         out.tab().tab().line('ks:')
         out.tab().tab().tab().line('description: Installation via kickstart')
         out.tab().tab().tab().line('rpms:')

--- a/genmodules.py
+++ b/genmodules.py
@@ -347,6 +347,15 @@ if __name__ == '__main__':
         if branch.is_dkms():
             out.tab().tab().tab().tab().line('- kmod-nvidia-latest-dkms')
 
+        out.tab().tab().line('ks:')
+        out.tab().tab().tab().line('description: Installation via kickstart')
+        out.tab().tab().tab().line('rpms:')
+        for pkg in sorted(existing_branch_pkgs):
+            if "cuda-drivers" not in pkg:
+                out.tab().tab().tab().tab().line('- ' + pkg)
+        if branch.is_dkms():
+            out.tab().tab().tab().tab().line('- kmod-nvidia-latest-dkms')
+
         out.next()
 
     out.line('document: modulemd-defaults')


### PR DESCRIPTION
* kickstart profile `/ks` that does not install cuda-drivers metapackage
* nvSwitch profile `/fm` for related branch-dependent software