### PR TITLE
Add nvidia-kmod-headers to "Artifacts" list for each stream

### DIFF
--- a/genmodules.py
+++ b/genmodules.py
@@ -55,6 +55,7 @@ BRANCH_PKGS = [
 
 # Add-ons
 OPTIONAL_PKGS = [
+  'nvidia-kmod-headers',
   'nvidia-fabric-manager',
 ]
 


### PR DESCRIPTION
Without this, installing the "src" profile for any branch would
always pull in the latest available nvidia-kmod-headers package.
For instance, "dnf module install nvidia-driver;450/src" would
install nvidia-kmod-headers-470.57.02-1.el8.x86_64.rpm as of
today (August 9, 2021).

Signed-off-by: Jamie Nguyen <jamien@nvidia.com>