### PR TITLE
515 rhel7 fix defattr inconsistency

### DIFF
--- a/kmod-nvidia.spec
+++ b/kmod-nvidia.spec
@@ -259,6 +259,8 @@ install -m 755 ld.gold %{buildroot}/%{_bindir}/ld.gold.nvidia.%{kmod_driver_vers
 %files
 %defattr(644,root,root,755)
 
+%attr(755,-,-) %{_bindir}/ld.gold.nvidia.%{kmod_driver_version}
+
 %{kmod_o_dir}
 %{kmod_share_dir}
 %{_bindir}/ld.gold.nvidia.%{kmod_driver_version}


### PR DESCRIPTION
Apply the recommendation in https://github.com/NVIDIA/yum-packaging-precompiled-kmod/issues/37

Sets the mode of the ld.gold to 755 which is what the spec expects when installing it https://github.com/NVIDIA/yum-packaging-precompiled-kmod/blob/515-rhel7/kmod-nvidia.spec#L255